### PR TITLE
Replace "Packages.swift" with "Package.swift".

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ After cloning the repository you can open it in Xcode.
 ```bash
 $ git clone https://github.com/Mikroservices/Smtp.git
 $ cd Smtp
-$ open Packages.swift
+$ open Package.swift
 ```
 You can build and run tests directly in Xcode.
 


### PR DESCRIPTION
In this directory there is no file called "Packages.swift". The closest filename is "Package.swift".