### PR TITLE
Make Attachment initializer public

### DIFF
--- a/Sources/Smtp/Models/Attachment.swift
+++ b/Sources/Smtp/Models/Attachment.swift
@@ -5,7 +5,7 @@ public struct Attachment {
     public let contentType: String
     public let data: Data
 
-    init(name: String, contentType: String, data: Data) {
+    public init(name: String, contentType: String, data: Data) {
         self.name = name
         self.contentType = contentType
         self.data = data


### PR DESCRIPTION
This will allow it to be used in `myEmail.addAttachment()`