### PR TITLE
Add possibility to use Request and Application 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ let email = Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John
                   subject: "The subject (text)",
                   body: "This is email body.")
 
-request.send(email).map { result in
+request.smtp.send(email).map { result in
     switch result {
     case .success:
         print("Email has been sent")
@@ -79,12 +79,20 @@ request.send(email).map { result in
 }
 ```
 
+Also you can send emails directly via `application` class.
+
+```swift
+app.smtp.send(email).map { result in
+    ...
+}
+```
+
 ## Troubleshoots
 
 You can use `logHandler` to handle and print all messages send/retrieved from email server.
 
 ```swift
-request.send(email) { message in
+request.smtp.send(email) { message in
     print(message)
 }.map { result in
     ...

--- a/Sources/Smtp/Request+Send.swift
+++ b/Sources/Smtp/Request+Send.swift
@@ -1,0 +1,23 @@
+import Foundation
+import NIO
+import NIOSSL
+import Vapor
+
+public extension Request {
+    var smtp: Smtp {
+        .init(request: self)
+    }
+
+    struct Smtp {
+        let request: Request
+
+        func send(_ email: Email, logHandler: ((String) -> Void)? = nil) -> EventLoopFuture<Result<Bool, Error>> {
+            return self.request.application.smtp.send(email, logHandler: logHandler)
+        }
+    }
+    
+    @available(*, deprecated, message: "Function is depraceted and will be deleted in Smtp 3.0. Please use: request.smtp.send() instead.")
+    func send(_ email: Email, logHandler: ((String) -> Void)? = nil) -> EventLoopFuture<Result<Bool, Error>> {
+        return self.application.smtp.send(email, logHandler: logHandler)
+    }
+}

--- a/Tests/SmtpTests/SmtpTests.swift
+++ b/Tests/SmtpTests/SmtpTests.swift
@@ -8,19 +8,19 @@ final class SmtpTests: XCTestCase {
     let smtpConfiguration = SmtpServerConfiguration(hostname: "smtp.mailtrap.io",
                                                     port: 465,
                                                     username: "8396cb1ecc7959",
-                                                    password: "#MAILTRAPPASS#",
+                                                    password: "29051e376bf674",
                                                     secure: .none)
 
     let sslSmtpConfiguration = SmtpServerConfiguration(hostname: "smtp.gmail.com",
                                                        port: 465,
                                                        username: "smtp.mikroservice@gmail.com",
-                                                       password: "#GMAILPASS#",
+                                                       password: "hyvvEf-7dengi-gokvuw",
                                                        secure: .ssl)
 
     let tslSmtpConfiguration = SmtpServerConfiguration(hostname: "smtp.gmail.com",
                                                        port: 587,
                                                        username: "smtp.mikroservice@gmail.com",
-                                                       password: "#GMAILPASS#",
+                                                       password: "hyvvEf-7dengi-gokvuw",
                                                        secure: .startTls)
 
     let timestamp = DateFormatter.localizedString(from: Date(), dateStyle: .medium, timeStyle: .short)
@@ -38,15 +38,36 @@ final class SmtpTests: XCTestCase {
                           body: "This is email body.")
         
         let request = Request(application: application, on: application.eventLoopGroup.next())
-        try request.send(email) { message in
+        try request.smtp.send(email) { message in
             print(message)
         }.flatMapThrowing { result in
             XCTAssertTrue(try result.get())
         }.wait()
-        
+
         sleep(3)
     }
 
+    func testSendTextMessageViaApplication() throws {
+        let application = Application()
+        defer {
+            application.shutdown()
+        }
+
+        application.smtp.configuration = smtpConfiguration
+        let email = Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
+                          to: [EmailAddress(address: "ben.doe@testxx.com", name: "Ben Doe")],
+                          subject: "The subject (text) - \(timestamp)",
+                          body: "This is email body.")
+        
+        try application.smtp.send(email) { message in
+            print(message)
+        }.flatMapThrowing { result in
+            XCTAssertTrue(try result.get())
+        }.wait()
+
+        sleep(3)
+    }
+    
     func testSendTextMessageWithoutNames() throws {
         let application = Application()
         defer {
@@ -60,7 +81,7 @@ final class SmtpTests: XCTestCase {
                           body: "This is email body.")
 
         let request = Request(application: application, on: application.eventLoopGroup.next())
-        try request.send(email) { message in
+        try request.smtp.send(email) { message in
             print(message)
         }.flatMapThrowing { result in
             XCTAssertTrue(try result.get())
@@ -83,7 +104,7 @@ final class SmtpTests: XCTestCase {
                           isBodyHtml: true)
 
         let request = Request(application: application, on: application.eventLoopGroup.next())
-        try request.send(email) { message in
+        try request.smtp.send(email) { message in
             print(message)
         }.flatMapThrowing { result in
             XCTAssertTrue(try result.get())
@@ -108,7 +129,7 @@ final class SmtpTests: XCTestCase {
         email.addAttachment(Attachment(name: "image.png", contentType: "image/png", data: Attachments.image()))
 
         let request = Request(application: application, on: application.eventLoopGroup.next())
-        try request.send(email) { message in
+        try request.smtp.send(email) { message in
             print(message)
         }.flatMapThrowing { result in
             XCTAssertTrue(try result.get())
@@ -134,7 +155,7 @@ final class SmtpTests: XCTestCase {
         email.addAttachment(Attachment(name: "image.png", contentType: "image/png", data: Attachments.image()))
 
         let request = Request(application: application, on: application.eventLoopGroup.next())
-        try request.send(email) { message in
+        try request.smtp.send(email) { message in
             print(message)
         }.flatMapThrowing { result in
             XCTAssertTrue(try result.get())
@@ -159,7 +180,7 @@ final class SmtpTests: XCTestCase {
                           body: "This is email body.")
 
         let request = Request(application: application, on: application.eventLoopGroup.next())
-        try request.send(email) { message in
+        try request.smtp.send(email) { message in
             print(message)
         }.flatMapThrowing { result in
             XCTAssertTrue(try result.get())
@@ -188,7 +209,7 @@ final class SmtpTests: XCTestCase {
                           body: "This is email body.")
 
         let request = Request(application: application, on: application.eventLoopGroup.next())
-        try request.send(email) { message in
+        try request.smtp.send(email) { message in
             print(message)
         }.flatMapThrowing { result in
             XCTAssertTrue(try result.get())
@@ -211,7 +232,7 @@ final class SmtpTests: XCTestCase {
                           replyTo: EmailAddress(address: "noreply@testxx.com"))
 
         let request = Request(application: application, on: application.eventLoopGroup.next())
-        try request.send(email) { message in
+        try request.smtp.send(email) { message in
             print(message)
         }.flatMapThrowing { result in
             XCTAssertTrue(try result.get())
@@ -236,7 +257,7 @@ final class SmtpTests: XCTestCase {
         email.addAttachment(Attachment(name: "image.png", contentType: "image/png", data: Attachments.image()))
 
         let request = Request(application: application, on: application.eventLoopGroup.next())
-        try request.send(email) { message in
+        try request.smtp.send(email) { message in
             print(message)
         }.flatMapThrowing { result in
             XCTAssertTrue(try result.get())
@@ -259,7 +280,7 @@ final class SmtpTests: XCTestCase {
         email.addAttachment(Attachment(name: "image.png", contentType: "image/png", data: Attachments.image()))
 
         let request = Request(application: application, on: application.eventLoopGroup.next())
-        try request.send(email) { message in
+        try request.smtp.send(email) { message in
             print(message)
         }.flatMapThrowing { result in
             XCTAssertTrue(try result.get())

--- a/Tests/SmtpTests/SmtpTests.swift
+++ b/Tests/SmtpTests/SmtpTests.swift
@@ -8,19 +8,19 @@ final class SmtpTests: XCTestCase {
     let smtpConfiguration = SmtpServerConfiguration(hostname: "smtp.mailtrap.io",
                                                     port: 465,
                                                     username: "8396cb1ecc7959",
-                                                    password: "29051e376bf674",
+                                                    password: "#MAILTRAPPASS#",
                                                     secure: .none)
 
     let sslSmtpConfiguration = SmtpServerConfiguration(hostname: "smtp.gmail.com",
                                                        port: 465,
                                                        username: "smtp.mikroservice@gmail.com",
-                                                       password: "hyvvEf-7dengi-gokvuw",
+                                                       password: "#GMAILPASS#",
                                                        secure: .ssl)
 
     let tslSmtpConfiguration = SmtpServerConfiguration(hostname: "smtp.gmail.com",
                                                        port: 587,
                                                        username: "smtp.mikroservice@gmail.com",
-                                                       password: "hyvvEf-7dengi-gokvuw",
+                                                       password: "#GMAILPASS#",
                                                        secure: .startTls)
 
     let timestamp = DateFormatter.localizedString(from: Date(), dateStyle: .medium, timeStyle: .short)


### PR DESCRIPTION
Currently we can send email via executing call:

```swift
request.send()
```

Change introduce possibility to use also `Application ` object. Thus we can now send emails via:

```swift
request.smtp.send()
```

or

```swift
application.smtp.send()
```