### PR TITLE
Added second Helo after TLS connection started

### DIFF
--- a/Sources/Smtp/Handlers/InboundSendEmailHandler.swift
+++ b/Sources/Smtp/Handlers/InboundSendEmailHandler.swift
@@ -9,6 +9,7 @@ internal final class InboundSendEmailHandler: ChannelInboundHandler {
         case initialMessageFromServer
         case okAfterHello
         case okAfterStartTls
+        case okAfterStartTlsHello
         case okAfterAuthBegin
         case okAfterUsername
         case okAfterPassword
@@ -72,6 +73,9 @@ internal final class InboundSendEmailHandler: ChannelInboundHandler {
             }
 
         case .okAfterStartTls:
+            self.send(context: context, command: .sayHelloAfterTls(serverName: self.serverConfiguration.hostname, helloMethod:  self.serverConfiguration.helloMethod))
+            self.currentlyWaitingFor = .okAfterStartTlsHello
+        case .okAfterStartTlsHello:
             self.send(context: context, command: .beginAuthentication)
             self.currentlyWaitingFor = .okAfterAuthBegin
         case .okAfterAuthBegin:

--- a/Sources/Smtp/Handlers/OutboundSmtpRequestEncoder.swift
+++ b/Sources/Smtp/Handlers/OutboundSmtpRequestEncoder.swift
@@ -11,6 +11,8 @@ internal final class OutboundSmtpRequestEncoder: MessageToByteEncoder {
             out.writeString("\(helloMethod.rawValue) \(server)")
         case .startTls:
             out.writeString("STARTTLS")
+        case .sayHelloAfterTls(serverName: let server, helloMethod: let helloMethod):
+            out.writeString("\(helloMethod.rawValue) \(server)")
         case .mailFrom(let from):
             out.writeString("MAIL FROM:<\(from)>")
         case .recipient(let rcpt):

--- a/Sources/Smtp/Models/SmtpRequest.swift
+++ b/Sources/Smtp/Models/SmtpRequest.swift
@@ -1,6 +1,7 @@
 internal enum SmtpRequest {
     case sayHello(serverName: String, helloMethod: HelloMethod)
     case startTls
+    case sayHelloAfterTls(serverName: String, helloMethod: HelloMethod)
     case beginAuthentication
     case authUser(String)
     case authPassword(String)


### PR DESCRIPTION
Some SMTP servers (e.g. smtp.office365.com ) require a second handshake after the initial start of the tls connection.