### PR TITLE
#18 Support only bcc recipients

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ try app.run()
 Using SMTP client.
 
 ```swift
-let email = Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
+let email = try! Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
                   to: [EmailAddress(address: "ben.doe@testxx.com", name: "Ben Doe")],
                   subject: "The subject (text)",
                   body: "This is email body.")

--- a/Sources/Smtp/Application+Send.swift
+++ b/Sources/Smtp/Application+Send.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 import Foundation
 import NIO
 import NIOSSL

--- a/Sources/Smtp/Application+Smtp.swift
+++ b/Sources/Smtp/Application+Smtp.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 import Vapor
 
 extension Application {

--- a/Sources/Smtp/Errors/EmailError.swift
+++ b/Sources/Smtp/Errors/EmailError.swift
@@ -3,8 +3,7 @@
 //  Copyright © 2021 Marcin Czachurski and the repository contributors.
 //  Licensed under the MIT License.
 //
-
-public enum HelloMethod: String {
-    case helo = "HELO"
-    case ehlo = "EHLO"
+    
+enum EmailError: Error {
+    case recipientNotSpecified
 }

--- a/Sources/Smtp/Errors/NIOExtrasError.swift
+++ b/Sources/Smtp/Errors/NIOExtrasError.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 import NIO
 
 internal protocol NIOExtrasError: Equatable, Error { }

--- a/Sources/Smtp/Errors/SmtpError.swift
+++ b/Sources/Smtp/Errors/SmtpError.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 import Foundation
 
 struct SmtpError: Error {

--- a/Sources/Smtp/Errors/SmtpResponseDecoderError.swift
+++ b/Sources/Smtp/Errors/SmtpResponseDecoderError.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 enum SmtpResponseDecoderError: Error {
     case malformedMessage
 }

--- a/Sources/Smtp/Handlers/DuplexMessagesHandler.swift
+++ b/Sources/Smtp/Handlers/DuplexMessagesHandler.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 import NIO
 
 internal final class DuplexMessagesHandler: ChannelDuplexHandler {

--- a/Sources/Smtp/Handlers/InboundLineBasedFrameDecoder.swift
+++ b/Sources/Smtp/Handlers/InboundLineBasedFrameDecoder.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 import NIO
 
 /// A decoder that splits incoming `ByteBuffer`s around line end

--- a/Sources/Smtp/Handlers/InboundSendEmailHandler.swift
+++ b/Sources/Smtp/Handlers/InboundSendEmailHandler.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 import NIO
 import NIOSSL
 
@@ -27,14 +33,16 @@ internal final class InboundSendEmailHandler: ChannelInboundHandler {
     private var email: Email
     private let serverConfiguration: SmtpServerConfiguration
     private let allDonePromise: EventLoopPromise<Void>
-    private var recipients: [EmailAddress]
+    private var recipients: [EmailAddress] = []
 
     init(configuration: SmtpServerConfiguration, email: Email, allDonePromise: EventLoopPromise<Void>) {
         self.email = email
         self.allDonePromise = allDonePromise
         self.serverConfiguration = configuration
 
-        self.recipients = self.email.to
+        if let to = self.email.to {
+            self.recipients += to
+        }
 
         if let cc = self.email.cc {
             self.recipients += cc

--- a/Sources/Smtp/Handlers/InboundSmtpResponseDecoder.swift
+++ b/Sources/Smtp/Handlers/InboundSmtpResponseDecoder.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 import NIO
 
 internal final class InboundSmtpResponseDecoder: ChannelInboundHandler {

--- a/Sources/Smtp/Handlers/OutboundSmtpRequestEncoder.swift
+++ b/Sources/Smtp/Handlers/OutboundSmtpRequestEncoder.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 import NIO
 import NIOFoundationCompat
 import Foundation

--- a/Sources/Smtp/Handlers/StartTlsHandler.swift
+++ b/Sources/Smtp/Handlers/StartTlsHandler.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 import NIO
 import NIOSSL
 

--- a/Sources/Smtp/Models/Attachment.swift
+++ b/Sources/Smtp/Models/Attachment.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 import Foundation
 
 public struct Attachment {

--- a/Sources/Smtp/Models/EmailAddress.swift
+++ b/Sources/Smtp/Models/EmailAddress.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 public struct EmailAddress {
     public let address: String
     public let name: String?

--- a/Sources/Smtp/Models/SmtpRequest.swift
+++ b/Sources/Smtp/Models/SmtpRequest.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 internal enum SmtpRequest {
     case sayHello(serverName: String, helloMethod: HelloMethod)
     case startTls

--- a/Sources/Smtp/Models/SmtpResponse.swift
+++ b/Sources/Smtp/Models/SmtpResponse.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 internal enum SmtpResponse {
     case ok(Int, String)
     case error(String)

--- a/Sources/Smtp/Request+Send.swift
+++ b/Sources/Smtp/Request+Send.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 import Foundation
 import NIO
 import NIOSSL

--- a/Sources/Smtp/SmtpSecure.swift
+++ b/Sources/Smtp/SmtpSecure.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 import Vapor
 import NIO
 import NIOSSL

--- a/Sources/Smtp/SmtpServerConfiguration.swift
+++ b/Sources/Smtp/SmtpServerConfiguration.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 import NIO
 import Vapor
 

--- a/Tests/SmtpTests/Attachments.swift
+++ b/Tests/SmtpTests/Attachments.swift
@@ -1,8 +1,7 @@
 //
-//  Attachments.swift
-//  SmtpTests
-//
-//  Created by Marcin Czachurski on 16/04/2019.
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
 //
 
 import Foundation

--- a/Tests/SmtpTests/SmtpTests.swift
+++ b/Tests/SmtpTests/SmtpTests.swift
@@ -1,3 +1,9 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+
 import XCTest
 import NIO
 import Vapor
@@ -32,7 +38,7 @@ final class SmtpTests: XCTestCase {
         }
 
         application.smtp.configuration = smtpConfiguration
-        let email = Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
+        let email = try! Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
                           to: [EmailAddress(address: "ben.doe@testxx.com", name: "Ben Doe")],
                           subject: "The subject (text) - \(timestamp)",
                           body: "This is email body.")
@@ -54,7 +60,7 @@ final class SmtpTests: XCTestCase {
         }
 
         application.smtp.configuration = smtpConfiguration
-        let email = Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
+        let email = try! Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
                           to: [EmailAddress(address: "ben.doe@testxx.com", name: "Ben Doe")],
                           subject: "The subject (text) - \(timestamp)",
                           body: "This is email body.")
@@ -75,7 +81,7 @@ final class SmtpTests: XCTestCase {
         }
 
         application.smtp.configuration = smtpConfiguration
-        let email = Email(from: EmailAddress(address: "john.doe@testxx.com"),
+        let email = try! Email(from: EmailAddress(address: "john.doe@testxx.com"),
                           to: [EmailAddress(address: "ben.doe@testxx.com")],
                           subject: "The subject (without names) - \(timestamp)",
                           body: "This is email body.")
@@ -97,7 +103,7 @@ final class SmtpTests: XCTestCase {
         }
 
         application.smtp.configuration = smtpConfiguration
-        let email = Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
+        let email = try! Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
                           to: [EmailAddress(address: "ben.doe@testxx.com", name: "Ben Doe")],
                           subject: "The subject (html) - \(timestamp)",
                           body: "<html><body><h1>This is email content!</h1></body></html>",
@@ -120,7 +126,7 @@ final class SmtpTests: XCTestCase {
         }
 
         application.smtp.configuration = smtpConfiguration
-        var email = Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
+        var email = try! Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
                           to: [EmailAddress(address: "ben.doe@testxx.com", name: "Ben Doe")],
                           subject: "The subject (text) - \(timestamp)",
                           body: "This is email body.")
@@ -145,7 +151,7 @@ final class SmtpTests: XCTestCase {
         }
 
         application.smtp.configuration = smtpConfiguration
-        var email = Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
+        var email = try! Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
                           to: [EmailAddress(address: "ben.doe@testxx.com", name: "Ben Doe")],
                           subject: "The subject (html) - \(timestamp)",
                           body: "<html><body><h1>This is email content!</h1></body></html>",
@@ -171,7 +177,7 @@ final class SmtpTests: XCTestCase {
         }
 
         application.smtp.configuration = smtpConfiguration
-        let email = Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
+        let email = try! Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
                           to: [
                             EmailAddress(address: "ben.doe@testxx.com", name: "Ben Doe"),
                             EmailAddress(address: "anton.doe@testxx.com", name: "Anton Doe")
@@ -196,7 +202,7 @@ final class SmtpTests: XCTestCase {
         }
 
         application.smtp.configuration = smtpConfiguration
-        let email = Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
+        let email = try! Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
                           to: [
                             EmailAddress(address: "ben.doe@testxx.com", name: "Ben Doe"),
                             EmailAddress(address: "anton.doe@testxx.com", name: "Anton Doe")
@@ -225,7 +231,7 @@ final class SmtpTests: XCTestCase {
         }
 
         application.smtp.configuration = smtpConfiguration
-        let email = Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
+        let email = try! Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
                           to: [EmailAddress(address: "ben.doe@testxx.com", name: "Ben Doe")],
                           subject: "The subject (reply-to) - \(timestamp)",
                           body: "This is email body.",
@@ -248,7 +254,7 @@ final class SmtpTests: XCTestCase {
         }
         
         application.smtp.configuration = sslSmtpConfiguration
-        var email = Email(from: EmailAddress(address: "smtp.mikroservice@gmail.com", name: "John Doe"),
+        var email = try! Email(from: EmailAddress(address: "smtp.mikroservice@gmail.com", name: "John Doe"),
                           to: [EmailAddress(address: "smtp.mikroservice@outlook.com", name: "Ben Doe")],
                           subject: "The subject (over SSL) - \(timestamp)",
                           body: "This is email body.")
@@ -271,7 +277,7 @@ final class SmtpTests: XCTestCase {
         }
 
         application.smtp.configuration = tslSmtpConfiguration
-        var email = Email(from: EmailAddress(address: "smtp.mikroservice@gmail.com", name: "John Doe"),
+        var email = try! Email(from: EmailAddress(address: "smtp.mikroservice@gmail.com", name: "John Doe"),
                           to: [EmailAddress(address: "smtp.mikroservice@outlook.com", name: "Ben Doe")],
                           subject: "The subject (over TSL) - \(timestamp)",
                           body: "This is email body.")
@@ -294,7 +300,7 @@ final class SmtpTests: XCTestCase {
         }
 
         application.smtp.configuration = smtpConfiguration
-        let email = Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
+        let email = try! Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
                           to: [EmailAddress(address: "ben.doe@testxx.com", name: "Ben Doe")],
                           cc: [EmailAddress(address: "july.doe@testxx.com", name: "July Doe"), EmailAddress(address: "viki.doe@testxx.com", name: "Viki Doe")],
                           bcc:[EmailAddress(address: "hidden1@testxx.com", name: "Hidden One"), EmailAddress(address: "hidden2@testxx.com", name: "Hidden Two")],
@@ -318,7 +324,7 @@ final class SmtpTests: XCTestCase {
         }
 
         application.smtp.configuration = smtpConfiguration
-        let email = Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
+        let email = try! Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
                           to: [EmailAddress(address: "ben.doe@testxx.com", name: "Ben Doe")],
                           subject: "The subject (reference) - \(timestamp)",
                           body: "This is email body.",
@@ -333,5 +339,39 @@ final class SmtpTests: XCTestCase {
         }.wait()
 
         sleep(3)
+    }
+    
+    func testSendOnlyBccTextMessage() throws {
+        let application = Application()
+        defer {
+            application.shutdown()
+        }
+
+        application.smtp.configuration = smtpConfiguration
+        let email = try! Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
+                               bcc:[EmailAddress(address: "hidden1@testxx.com", name: "Hidden One"), EmailAddress(address: "hidden2@testxx.com", name: "Hidden Two")],
+                               subject: "The subject (only bcc) - \(timestamp)",
+                               body: "This is email body.")
+
+        let request = Request(application: application, on: application.eventLoopGroup.next())
+        try request.smtp.send(email) { message in
+            print(message)
+        }.flatMapThrowing { result in
+            XCTAssertTrue(try result.get())
+        }.wait()
+
+        sleep(3)
+    }
+    
+    func testEmailWithoutRecipientsCannotBeInitialized() throws {
+        XCTAssertThrowsError(
+            try Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
+                      subject: "The subject (reference) - \(timestamp)",
+                      body: "This is email body.",
+                      reference: "<53455345@testxx.com>"
+            )
+        ) { error in
+            XCTAssertEqual(error as! EmailError, EmailError.recipientNotSpecified)
+        }
     }
 }


### PR DESCRIPTION
Now we can write code:

```swift
let email = try! Email(from: EmailAddress(address: "john.doe@testxx.com", name: "John Doe"),
                       bcc:[EmailAddress(address: "hidden1@testxx.com", name: "Hidden One"), EmailAddress(address: "hidden2@testxx.com", name: "Hidden Two")],
                       subject: "The subject (only bcc)",
                       body: "This is email body.")

try request.smtp.send(email)
```

Emails will be send only to BCC recipients.
