### PR TITLE
Feature/aunonymous user

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ let app = Application(env)
 defer { app.shutdown() }
 
 app.smtp.configuration.host = "smtp.server"
-app.smtp.configuration.username = "johndoe"
-app.smtp.configuration.password = "passw0rd"
+app.smtp.configuration.signInMethod = .credentials(username: "johndoe", password: "passw0rd")
 app.smtp.configuration.secure = .ssl
 
 try configure(app)

--- a/Sources/Smtp/Models/SignInMethod.swift
+++ b/Sources/Smtp/Models/SignInMethod.swift
@@ -3,6 +3,8 @@
 //  Copyright © 2021 Marcin Czachurski and the repository contributors.
 //  Licensed under the MIT License.
 //
-    
 
-import Foundation
+public enum SignInMethod {
+    case anonymous
+    case credentials(username: String, password: String)
+}

--- a/Sources/Smtp/Models/SignInMethod.swift
+++ b/Sources/Smtp/Models/SignInMethod.swift
@@ -1,0 +1,8 @@
+//
+//  https://mczachurski.dev
+//  Copyright © 2021 Marcin Czachurski and the repository contributors.
+//  Licensed under the MIT License.
+//
+    
+
+import Foundation

--- a/Sources/Smtp/Request+Send.swift
+++ b/Sources/Smtp/Request+Send.swift
@@ -21,9 +21,4 @@ public extension Request {
             return self.request.application.smtp.send(email, eventLoop: self.request.eventLoop, logHandler: logHandler)
         }
     }
-    
-    @available(*, deprecated, message: "Function is depraceted and will be deleted in Smtp 3.0. Please use: request.smtp.send() instead.")
-    func send(_ email: Email, logHandler: ((String) -> Void)? = nil) -> EventLoopFuture<Result<Bool, Error>> {
-        return self.application.smtp.send(email, eventLoop: self.eventLoop, logHandler: logHandler)
-    }
 }

--- a/Sources/Smtp/SmtpServerConfiguration.swift
+++ b/Sources/Smtp/SmtpServerConfiguration.swift
@@ -10,26 +10,23 @@ import Vapor
 public struct SmtpServerConfiguration {
     public var hostname: String
     public var port: Int
-    public var username: String
-    public var password: String
     public var secure: SmtpSecureChannel
     public var connectTimeout:TimeAmount
     public var helloMethod: HelloMethod
+    public var signInMethod: SignInMethod
 
     public init(hostname: String = "",
                 port: Int = 465,
-                username: String = "",
-                password: String = "",
+                signInMethod: SignInMethod = .anonymous,
                 secure: SmtpSecureChannel = .none,
                 connectTimeout: TimeAmount = TimeAmount.seconds(10),
                 helloMethod: HelloMethod = .helo
     ) {
         self.hostname = hostname
         self.port = port
-        self.username = username
-        self.password = password
         self.secure = secure
         self.connectTimeout = connectTimeout
         self.helloMethod = helloMethod
+        self.signInMethod = signInMethod
     }
 }

--- a/Tests/SmtpTests/SmtpTests.swift
+++ b/Tests/SmtpTests/SmtpTests.swift
@@ -13,20 +13,17 @@ final class SmtpTests: XCTestCase {
 
     let smtpConfiguration = SmtpServerConfiguration(hostname: "smtp.mailtrap.io",
                                                     port: 465,
-                                                    username: "#MAILTRAPUSER#",
-                                                    password: "#MAILTRAPPASS#",
+                                                    signInMethod: .credentials(username: "#MAILTRAPUSER#", password: "#MAILTRAPPASS#"),
                                                     secure: .none)
 
     let sslSmtpConfiguration = SmtpServerConfiguration(hostname: "smtp.gmail.com",
                                                        port: 465,
-                                                       username: "#GMAILUSER#",
-                                                       password: "#GMAILPASS#",
+                                                       signInMethod: .credentials(username: "#GMAILUSER#", password: "#GMAILPASS#"),
                                                        secure: .ssl)
 
     let tslSmtpConfiguration = SmtpServerConfiguration(hostname: "smtp.gmail.com",
                                                        port: 587,
-                                                       username: "#GMAILUSER#",
-                                                       password: "#GMAILPASS#",
+                                                       signInMethod: .credentials(username: "#GMAILUSER#", password: "#GMAILPASS#"),
                                                        secure: .startTls)
 
     let timestamp = DateFormatter.localizedString(from: Date(), dateStyle: .medium, timeStyle: .short)


### PR DESCRIPTION
Now we can user '.anonymous' as sign in method. For example:

```swift
let app = Application(env)
defer { app.shutdown() }

app.smtp.configuration.host = "smtp.server"
app.smtp.configuration.signInMethod = .anonymous
app.smtp.configuration.secure = .ssl

try configure(app)
try app.run()
```