### PR TITLE
Fix for extra empty attachment "ATT00001" in most email clients

### DIFF
--- a/Sources/Smtp/Models/Email.swift
+++ b/Sources/Smtp/Models/Email.swift
@@ -113,13 +113,19 @@ extension Email {
                 out.writeString("\(self.body)\r\n\r\n")
                 out.writeString("--\(boundary)\r\n")
             }
-
-            for attachment in self.attachments {
+            //Close the last email boundary using --
+            for (index, attachment) in self.attachments.enumerated() {
                 out.writeString("Content-type: \(attachment.contentType)\r\n")
                 out.writeString("Content-Transfer-Encoding: base64\r\n")
                 out.writeString("Content-Disposition: attachment; filename=\"\(attachment.name)\"\r\n\r\n")
                 out.writeString("\(attachment.data.base64EncodedString())\r\n")
-                out.writeString("--\(boundary)\r\n")
+                
+                if index == self.attachments.count - 1
+                {
+                    out.writeString("--\(boundary)--\r\n")
+                } else {
+                    out.writeString("--\(boundary)\r\n")
+                }
             }
 
         } else {


### PR DESCRIPTION
This issue addresses a bug related to sending emails with attachments, where an annoying empty attachment is inadvertently added. The fix ensures that emails with legitimate attachments are sent correctly without any unintended empty attachments being included.