### PR TITLE
feat: contentID for email attachments

### DIFF
--- a/Sources/Smtp/Models/Attachment.swift
+++ b/Sources/Smtp/Models/Attachment.swift
@@ -10,10 +10,12 @@ public struct Attachment {
     public let name: String
     public let contentType: String
     public let data: Data
+    public let contentID: String?
 
-    public init(name: String, contentType: String, data: Data) {
+    public init(name: String, contentType: String, data: Data,  contentID: String? = nil) {
         self.name = name
         self.contentType = contentType
         self.data = data
+        self.contentID = contentID
     }
 }

--- a/Sources/Smtp/Models/Email.swift
+++ b/Sources/Smtp/Models/Email.swift
@@ -122,6 +122,9 @@ extension Email {
             for (index, attachment) in self.attachments.enumerated() {
                 out.writeString("Content-type: \(attachment.contentType)\r\n")
                 out.writeString("Content-Transfer-Encoding: base64\r\n")
+                if let contentID = attachment.contentID  {
+                    out.writeString("Content-ID: \(contentID)\r\n")
+                }
                 out.writeString("Content-Disposition: attachment; filename=\"\(attachment.name)\"\r\n\r\n")
                 out.writeString("\(attachment.data.base64EncodedString())\r\n")
                 


### PR DESCRIPTION
Write content id for email attachments so attachments can be referenced in html body. See [here](https://stackoverflow.com/questions/922898/embedding-attached-images-in-html-emails)

See [RFC](https://www.ietf.org/rfc/rfc2045.txt#:~:text=base64%20encoding.%0A%0A7.-,Content,-%2DID%20Header%20Field)